### PR TITLE
Remove duplicate field shortname

### DIFF
--- a/NeurIPSCDT-2020.bib
+++ b/NeurIPSCDT-2020.bib
@@ -10,7 +10,6 @@
     published = {2021-08-07},
     url = {https://neurips.cc/Conferences/2020/CompetitionTrack},
     address = {Virtual},
-    shortname = {NeurIPSCDT}
 }
 
 


### PR DESCRIPTION
This commit removes the duplicate field shortname from the proceedings bibtex entry.